### PR TITLE
fix(ci): Fixes NPM deploys and renames to @artsy/dismissible 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# @artsy/npm-package-starter
+# @artsy/dismissible
 
-A starter repo for publishing `@artsy` packages to NPM, which includes common CI setup and PR-label based semantic releases via [Auto](https://intuit.github.io/auto/index).
+A package that stores dismissible key/value entries in localStorage, which can be used in apps that require progressive onboarding and the like.
+
+## Use
+
+TODO
 
 ## Commands
 
@@ -11,46 +15,3 @@ yarn lint
 yarn compile
 yarn watch
 ```
-
-## Overview
-
-There are a few key tools that we use for our publishing pipeline. Notably
-
-- [Auto](https://github.com/intuit/auto): Generate releases based on semantic version labels on pull requests
-- [Artsy's CircleCI Orbs](https://github.com/artsy/orbs): Orbs are packages of CircleCI configuration that can be shared across projects
-
-Combining these things together, we get seamless DX around releases that can be triggered directly from PRs via labels, and minimal CI config for running common script commands in an ideal way. Additionally, an automated changelog is generated for every release.
-
-## Setup
-
-Since much of this functionality relies on Artsy's Github and CircleCI org membership, there are a few setup steps before everything will work:
-
-- Create a new repo on Github under the Artsy namespace and copy the files from this example repo into it. Commit and push to `main`.
-- Go to https://github.com/artsy/your-repo-name/settings/access, click `Add Teams`, and then add `Engineering`
-- Then [go to CircleCI](https://app.circleci.com/projects/project-dashboard/github/artsy/), find the new repo, and click the little "gear" icon to set up
-- As CircleCI should automatically pick up the [`.circleci/config.yml` file](https://github.com/artsy/npm-package-starter/blob/main/.circleci/config.yml), select the `Fastest` option and enter `main` for the branch. Click `Set up Project`
-- Add `NPM_TOKEN` and `GH_TOKEN` environment variables via the [settings page](https://app.circleci.com/settings/project/github/artsy/your-app-name/environment-variables) (details are in 1pass)
-- This will allow Auto to write a message to the GitHub PR notifying devs that the package has been published, along with the version number, as well as increment the version number in `package.json`
-- Update the package name in [`package.json`](https://github.com/artsy/npm-package-starter/blob/main/package.json#L2)
-- Done!
-
-Once these steps are completed the new repo should be able to access NPM authentication, our shared Auto config and more.
-
-## Typical Developer Workflow
-
-- Open PR
-- Tag PR with correct semantic-release label (by default, `patch` is applied)
-- Merge PR
-- Release is sent to NPM and the merged PR is updated with a comment indicating the version that was just published
-- If needing to release a `canary` version for testing, tag PR with a `canary` label. In a few moments the PR description will update with a link to the canary that was just published
-
-### Deeper Dive
-
-For those looking to understand how these pieces fit together within our Github Org, read on!
-
-- The file responsible for connecting label-based publishing together is [`.autorc`](https://github.com/artsy/npm-package-starter/blob/main/.autorc)
-- Within `.autorc` is `"extends": "@artsy"`, which points at our [shared Auto config](https://github.com/artsy/auto-config). This is where we define the various labels that will perform various functions
-- For running tests and other chores on CI, [see `.circleci/config.yml`](https://github.com/artsy/npm-package-starter/blob/main/.circleci/config.yml)
-- Inside of that file you'll see jobs like [`yarn/test`](https://github.com/artsy/npm-package-starter/blob/main/.circleci/config.yml#L20)
-- Notice how there's nothing pointing to a script in `package.json`? This is due to how we've setup [sensible defaults](https://github.com/artsy/orbs/blob/main/src/yarn/yarn.yml#L110) via CircleCI Orbs. It is assumed that one has these scripts already setup in their `package.json`
-- All of the various authentication-token needs are also managed from within here, in the `pre-release` [job](https://github.com/artsy/orbs/blob/main/src/yarn/yarn.yml#L65-L71)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "watch": "tsc -p . --watch"
   },
   "devDependencies": {
+    "@artsy/auto-config": "^1.2.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@types/jest": "^29.1.2",
     "@types/lodash.uniqby": "^4.7.9",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@artsy/progressive-onboarding",
+  "name": "@artsy/dismissible",
   "version": "0.0.0",
   "main": "dist/index.js",
   "license": "MIT",

--- a/src/DismissibleContext.tsx
+++ b/src/DismissibleContext.tsx
@@ -8,11 +8,11 @@ import React, {
 } from "react"
 import uniqBy from "lodash.uniqby"
 
-export type ProgressiveOnboardingKey = ContextProps["keys"][number]
-export type ProgressiveOnboardingKeys = ProgressiveOnboardingKey[]
+export type DismissibleKey = DismissibleContextProps["keys"][number]
+export type DismissibleKeys = DismissibleKey[]
 
 interface DismissedKey {
-  key: ProgressiveOnboardingKey
+  key: DismissibleKey
   timestamp: number
 }
 
@@ -21,12 +21,10 @@ interface DismissedKeyStatus {
   timestamp: number
 }
 
-export interface ContextProps {
+export interface DismissibleContextProps {
   dismissed: DismissedKey[]
-  dismiss: (
-    key: ProgressiveOnboardingKey | readonly ProgressiveOnboardingKey[]
-  ) => void
-  isDismissed: (key: ProgressiveOnboardingKey) => DismissedKeyStatus
+  dismiss: (key: DismissibleKey | readonly DismissibleKey[]) => void
+  isDismissed: (key: DismissibleKey) => DismissedKeyStatus
   keys: string[]
   syncFromLoggedOutUser: () => void
   /** An optional userID to track against  */
@@ -34,16 +32,16 @@ export interface ContextProps {
   __internal__: ReturnType<typeof useLocalStorageUtils>
 }
 
-export const Context = createContext<ContextProps>({
+export const DismissibleContext = createContext<DismissibleContextProps>({
   dismissed: [],
   keys: [],
   isDismissed: () => ({ status: false, timestamp: 0 }),
-} as unknown as ContextProps)
+} as unknown as DismissibleContextProps)
 
-export const Provider: React.FC<{
+export const DismissibleProvider: React.FC<{
   children: React.ReactNode
-  keys: ProgressiveOnboardingKeys
-  userID?: ContextProps["userID"]
+  keys: DismissibleKeys
+  userID?: DismissibleContextProps["userID"]
 }> = ({ children, keys = [], userID }) => {
   const id = userID ?? PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID
 
@@ -53,7 +51,7 @@ export const Provider: React.FC<{
   const { __dismiss__, get } = localStorageUtils
 
   const dismiss = useCallback(
-    (key: ProgressiveOnboardingKey | ProgressiveOnboardingKey[]) => {
+    (key: DismissibleKey | DismissibleKey[]) => {
       const keys = Array.isArray(key) ? key : [key]
       const timestamp = Date.now()
 
@@ -76,7 +74,7 @@ export const Provider: React.FC<{
   const mounted = useDidMount()
 
   const isDismissed = useCallback(
-    (key: ProgressiveOnboardingKey) => {
+    (key: DismissibleKey) => {
       if (!mounted) {
         return {
           status: false,
@@ -137,7 +135,7 @@ export const Provider: React.FC<{
   }, [id])
 
   return (
-    <Context.Provider
+    <DismissibleContext.Provider
       value={{
         dismissed,
         dismiss,
@@ -148,12 +146,12 @@ export const Provider: React.FC<{
       }}
     >
       {children}
-    </Context.Provider>
+    </DismissibleContext.Provider>
   )
 }
 
-export const useProgressiveOnboardingContext = () => {
-  return useContext(Context)
+export const useDismissibleContext = () => {
+  return useContext(DismissibleContext)
 }
 
 export const PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID = "user" as const
@@ -163,7 +161,7 @@ export const localStorageKey = (id: string) => {
 }
 
 interface UseLocalStorageUtilsProps {
-  keys: ContextProps["keys"]
+  keys: DismissibleContextProps["keys"]
 }
 
 export const useLocalStorageUtils = ({ keys }: UseLocalStorageUtilsProps) => {
@@ -193,7 +191,7 @@ export const useLocalStorageUtils = ({ keys }: UseLocalStorageUtilsProps) => {
   const __dismiss__ = (
     id: string,
     timestamp: number,
-    key: ProgressiveOnboardingKey | ProgressiveOnboardingKey[]
+    key: DismissibleKey | DismissibleKey[]
   ) => {
     const keys = Array.isArray(key) ? key : [key]
 

--- a/src/__tests__/DismissibleContext.jest.tsx
+++ b/src/__tests__/DismissibleContext.jest.tsx
@@ -2,13 +2,13 @@ import React from "react"
 import { renderHook } from "@testing-library/react-hooks"
 import {
   PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID,
-  Provider,
+  DismissibleProvider,
   useLocalStorageUtils,
-  useProgressiveOnboardingContext,
+  useDismissibleContext,
   localStorageKey,
-} from "../Context"
+} from "../DismissibleContext"
 
-describe("ProgressiveOnboardingContext", () => {
+describe("DismissibleContext", () => {
   const keys = ["follow-artist", "follow-find", "follow-highlight"]
   const id = "example-id"
 
@@ -159,13 +159,13 @@ describe("ProgressiveOnboardingContext", () => {
     afterEach(() => reset(id))
 
     const wrapper = ({ children }: { children: React.ReactNode }) => (
-      <Provider keys={keys} userID={id}>
+      <DismissibleProvider keys={keys} userID={id}>
         {children}
-      </Provider>
+      </DismissibleProvider>
     )
 
     it("dismisses keys", () => {
-      const { result } = renderHook(useProgressiveOnboardingContext, {
+      const { result } = renderHook(useDismissibleContext, {
         wrapper,
       })
 
@@ -215,11 +215,11 @@ describe("ProgressiveOnboardingContext", () => {
 
   describe("syncFromLoggedOutUser", () => {
     it("does nothing if the user is logged out", () => {
-      const { result } = renderHook(useProgressiveOnboardingContext, {
+      const { result } = renderHook(useDismissibleContext, {
         wrapper: ({ children }: { children: React.ReactNode }) => (
-          <Provider keys={keys} userID={id}>
+          <DismissibleProvider keys={keys} userID={id}>
             {children}
-          </Provider>
+          </DismissibleProvider>
         ),
       })
 
@@ -244,11 +244,11 @@ describe("ProgressiveOnboardingContext", () => {
 
         expect(get(id)).toEqual([])
 
-        const { result } = renderHook(useProgressiveOnboardingContext, {
+        const { result } = renderHook(useDismissibleContext, {
           wrapper: ({ children }: { children: React.ReactNode }) => (
-            <Provider keys={keys} userID={id}>
+            <DismissibleProvider keys={keys} userID={id}>
               {children}
-            </Provider>
+            </DismissibleProvider>
           ),
         })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export {
-  Provider as ProgressiveOnboardingProvider,
-  useProgressiveOnboardingContext,
-} from "./Context"
+  DismissibleProvider,
+  useDismissibleContext,
+} from "./DismissibleContext"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,11 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
+"@artsy/auto-config@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@artsy/auto-config/-/auto-config-1.2.0.tgz#62a237ca3a058f1b91e5b8a12abebae0ddc5bd2f"
+  integrity sha512-6zGlvqELl4XhqMajJxfgHaY3m5YhZK5FwkxlouJKSb0Su301bzXaPUxKjzj9X147YHJUyrRLSAruzVtj1Gr42Q==
+
 "@auto-it/bot-list@10.37.6":
   version "10.37.6"
   resolved "https://registry.yarnpkg.com/@auto-it/bot-list/-/bot-list-10.37.6.tgz#3ca9380a44b9c8d33b2088b8fed2c2ffc79c91ed"


### PR DESCRIPTION
Updates a few things. Notably, we were lacking `@artsy/auto-config`, which configures all of the things. 

Also renames to `@artsy/dismissible`, as that's a better name for the generic properties of a dismissible key/value localStorage util. 

Future updates will include an adaptor, so that we can swap in RN localStorage adaptors and simplify storage on Eigen et al. 