### PR TITLE
feat: add addKey function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,48 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@6.2.0
-  auto: artsy/auto@2.1.0
+  auto: artsy/auto@2.2.0
+  node: circleci/node@6.3.0
 
 workflows:
   build_and_verify:
     jobs:
-      - yarn/workflow-queue
-      - yarn/update-cache:
-          requires:
-            - yarn/workflow-queue
-      - yarn/lint:
-          requires:
-            - yarn/workflow-queue
-      - yarn/type-check:
-          requires:
-            - yarn/workflow-queue
-      - yarn/test:
-          requires:
-            - yarn/workflow-queue
+      - node/run:
+          name: lint
+          pkg-manager: yarn
+          yarn-run: lint
+          version: 18.15.0
+
+      - node/run:
+          name: type-check
+          pkg-manager: yarn
+          yarn-run: type-check
+          version: 18.15.0
+
+      - node/run:
+          name: test
+          pkg-manager: yarn
+          yarn-run: test
+          version: 18.15.0
+
       - auto/publish-canary:
           context: npm-deploy
           filters:
             branches:
               ignore: main
+          node-version: "16.10.0"
           requires:
-            - yarn/test
-            - yarn/lint
-            - yarn/type-check
-            - yarn/update-cache
+            - test
+            - lint
+            - type-check
+
       - auto/publish:
           context: npm-deploy
           filters:
             branches:
               only: main
+          node-version: "16.10.0"
           requires:
-            - yarn/test
-            - yarn/lint
-            - yarn/type-check
-            - yarn/update-cache
+            - test
+            - lint
+            - type-check

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `useDismissibleContext` hook returns a few useful things for managing dismis
 
 ```jsx
 const App = () => {
-  const { dismiss, dismissed, isDismissed, keys, syncFromLoggedOutUser } =
+  const { dismiss, dismissed, isDismissed, keys, addKey syncFromLoggedOutUser } =
     useDismissibleContext()
 
   // Dismisses a key
@@ -70,6 +70,9 @@ const App = () => {
 
   // Status of the thing dismissed, including timestamp
   isDismissied("id")
+
+  // Add a new key at runtime
+  addKey("otherID")
 
   // If a logged-out user logs in, resync so that dismissed keys don't reappear
   syncFromLoggedOutUser()


### PR DESCRIPTION
This updates things with a new API function `addKey`, which dynamically allows us to add keys during runtime. Things shouldn't _only_ be dismissible, and initialized on boot. We should be able to add UX interactions allow (and then dismiss later).  

(This came up around showing the survey link post batch-import complete)
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.4.0--canary.8.150.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @artsy/dismissible@0.4.0--canary.8.150.0
  # or 
  yarn add @artsy/dismissible@0.4.0--canary.8.150.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
