### PR TITLE
fix: assume dismissibles are dismissed until mounted

### DIFF
--- a/src/DismissibleContext.tsx
+++ b/src/DismissibleContext.tsx
@@ -36,7 +36,7 @@ interface DismissibleContextProps {
 const DismissibleContext = createContext<DismissibleContextProps>({
   dismissed: [],
   keys: [],
-  isDismissed: () => ({ status: false, timestamp: 0 }),
+  isDismissed: () => ({ status: true, timestamp: 0 }),
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   addKey: () => {},
 } as unknown as DismissibleContextProps)

--- a/src/DismissibleContext.tsx
+++ b/src/DismissibleContext.tsx
@@ -93,7 +93,7 @@ export const DismissibleProvider: React.FC<{
     (key: DismissibleKey) => {
       if (!mounted) {
         return {
-          status: false,
+          status: true,
           timestamp: 0,
         }
       }

--- a/src/DismissibleContext.tsx
+++ b/src/DismissibleContext.tsx
@@ -48,14 +48,7 @@ export const DismissibleProvider: React.FC<{
 }> = ({ children, keys: initialKeys = [], userID }) => {
   const id = userID ?? DISMISSIBLE_LOGGED_OUT_USER_ID
 
-  const [keys, setKeys] = useState<DismissibleKeys>(() => {
-    const storedKeys = loadKeysFromStorage(initialKeys)
-
-    return [
-      ...initialKeys,
-      ...storedKeys, // Keys were added from elsewhere, via addKey
-    ]
-  })
+  const [keys, setKeys] = useState<DismissibleKeys>(initialKeys)
 
   const [dismissed, setDismissed] = useState<DismissedKey[]>([])
   const localStorageUtils = useLocalStorageUtils({ keys })
@@ -86,6 +79,13 @@ export const DismissibleProvider: React.FC<{
   useEffect(() => {
     setDismissed(get(id))
   }, [id])
+
+  useEffect(() => {
+    const storedKeys = loadKeysFromStorage(initialKeys)
+    if (storedKeys.length > 0) {
+      setKeys((prev) => [...prev, ...storedKeys])
+    }
+  }, [])
 
   const mounted = useDidMount()
 
@@ -195,11 +195,6 @@ export const localStorageKey = (id: string) => {
 }
 
 const loadKeysFromStorage = (initialKeys: DismissibleKeys): DismissibleKeys => {
-  // Make SSR safe
-  if (typeof window === "undefined") {
-    return []
-  }
-
   const allStorageKeys = Array.from(
     { length: localStorage.length },
     (_, index) => localStorage.key(index)


### PR DESCRIPTION
This PR addresses a bug described in artsy/force#17196 where a ton of events are being logged in Sentry in response to tooltips being optimistically rendered in the SSR and raising the following error on the client-side when they are not needed:

> Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.

This bug is not visible to users, but it is consuming a lot of our Sentry allowance, so I would like to silence it by addressing the root cause.

I believe the root cause is that this library is reporting that a dismissible has _not_ been dismissed (and should be rendered) while it is waiting to mount, at which point it will be able to check local storage and see whether it has actually been dismissed. This PR flips that assumption around and makes it report that a dismissible has been dismissed (and should not be rendered) until it knows for sure.

A side effect of this change is that tooltips will appear a bit more slowly than they did when rendered on the server-side, but it should not be noticeable to the human eye.

cc: @artsy/diamond-devs 